### PR TITLE
Add SSH agent auto-launch instructions and service file

### DIFF
--- a/ssh-agent/README.md
+++ b/ssh-agent/README.md
@@ -1,0 +1,34 @@
+# Running SSH Agent automatically
+
+This solution is from the following source:
+<https://stackoverflow.com/questions/18880024/start-ssh-agent-on-login>
+
+## Solution
+
+Create the following `~/.config/systemd/user/ssh-agent.service` with this content.
+
+```text
+[Unit]
+Description=SSH key agent
+
+[Service]
+Type=simple
+Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
+ExecStart=/usr/bin/ssh-agent -D -a $SSH_AUTH_SOCK
+
+[Install]
+WantedBy=default.target
+```
+
+Also add this to `~/.ssh/config`
+
+```text
+AddKeysToAgent  yes
+```
+
+then start the processes
+
+```shell
+systemctl --user enable ssh-agent
+systemctl --user start ssh-agent
+```

--- a/ssh-agent/ssh-agent.service
+++ b/ssh-agent/ssh-agent.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=SSH key agent
+
+[Service]
+Type=simple
+Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
+ExecStart=/usr/bin/ssh-agent -D -a $SSH_AUTH_SOCK
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This update introduces a systemd service for automatically starting the SSH agent on user login. It includes detailed instructions for creating the service file and configuring SSH to add keys to the agent. This solution enhances user experience by ensuring the SSH agent is always running when needed.

Fixes #113