### PR TITLE
Forcing Bluetooth Codec to stay the same

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,6 +61,7 @@
         "Virt",
         "Wetty",
         "wettyoss",
+        "wireplumber",
         "wlan",
         "wmname",
         "xorg",

--- a/guides/WirePlumberAutoswitchDisable.md
+++ b/guides/WirePlumberAutoswitchDisable.md
@@ -1,0 +1,22 @@
+# WirePlumber Auto-switch Disable
+
+WirePlumber is a session manager for PipeWire, which is used for handling audio and video streams. By default, WirePlumber may automatically switch audio codecs for Bluetooth devices, which can be inconvenient in some cases. This guide will help you disable the auto-switching feature for Bluetooth devices in WirePlumber.
+
+## Steps to Disable Auto-switching
+
+1. **Create or Edit the Configuration File**:
+    Create a new configuration file or edit an existing one.
+     ```bash
+     vim ~/.config/wireplumber/wireplumber.conf.d/11-bluetooth-policy.conf
+     ```
+3. **Disable Auto-switching**:
+    Add the following lines to the configuration file to disable auto-switching:
+     ```conf
+     wireplumber.settings = {
+        bluetooth.autoswitch-to-headset-profile = false
+    }
+     ```
+4. **Save and Exit**:
+    Save the changes and exit the text editor.
+5. **Reboot**:
+    Reboot your system.


### PR DESCRIPTION
Add a guide to disable the auto-switching feature for Bluetooth codecs in WirePlumber, ensuring consistent audio quality during gaming. Update settings to include WirePlumber in the configuration.

Fixes #112