### PR TITLE
Remove Nvidia driver section and update installation instructions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "chsh",
         "cronie",
         "devel",
+        "dkms",
         "dmenu",
         "dnsmasq",
         "Gibibyte",

--- a/guides/NvidiaGPU.md
+++ b/guides/NvidiaGPU.md
@@ -1,14 +1,25 @@
 # Nvidia GPU
 
+If you are using the `archinstall` for installing, you should have an option to install the Nvidia drivers. This will be done for you automatically.
+
 ## Installation
 
 Installing Nvidia GPU requirements is easy. Just run the following:
 
 ```shell
-paru -S nvidia lib32-nvidia-utils
+paru -S nvidia-dkms nvidia-utils lib32-nvidia-utils
 ```
 
-## Accessing Dedicated GPU in Hybrid Graphics System
+### What is `dkms`?
+
+`dkms` is a framework that allows you to automatically rebuild kernel modules when a new kernel is installed. This is particularly useful for Nvidia drivers, as they often need to be rebuilt for each new kernel version.
+
+### What is `lib32-nvidia-utils`?
+
+`lib32-nvidia-utils` is a package that provides 32-bit Nvidia libraries. This is necessary for running 32-bit applications that require Nvidia drivers, such as some games or software.
+
+## Accessing Dedicated GPU in Hybrid Graphics System (Mostly Laptops)
+If you have a hybrid graphics system (like Intel + Nvidia), you may need to configure your system to use the dedicated GPU for certain applications. This is common in laptops that have both integrated and dedicated graphics.
 
 You can use [PRIME](https://wiki.archlinux.org/title/PRIME) to access the dedicated GPU.
 
@@ -27,23 +38,3 @@ DISPLAY=:0 prime-run glxinfo | grep "OpenGL renderer"
 ```
 
 Additionally, programs like Blender or Steam (Proton) do not need to be executed by the `prime-run` command. They can detect the dedicated GPU and offload the computation to that GPU nonetheless (they may need some settings altered).
-
-## Tweaking Some Boot Params
-
-⚠️ These are specific to my workstation and may vary depending on the hardware.
-
-`ibt=off` and `split_lock_detect=off` should be added to the end of `options` section in the `/boot/loader/entries/<filename>.conf` (assuming you are using `systemd-boot`).
-
-Example:
-
-```conf
-# Created by: archinstall
-# Created on: yyyy-mm-dd_hh-mm-ss
-title Arch Linux (linux)
-linux /vmlinuz-linux
-initrd /intel-ucode.img
-initrd /initramfs-linux.img
-options root=PARTUUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx zswap.enabled=0 rw intel_pstate=no_hwp rootfstype=ext4 ibt=off split_lock_detect=off
-```
-
-If you are interested to know the reasons, check [here](https://wiki.archlinux.org/title/NVIDIA#Installation) and [here](https://www.reddit.com/r/VFIO/comments/zqesqm/psa_use_split_lock_detectoff_to_avoid_substantial/)


### PR DESCRIPTION
The Nvidia driver section has been removed in favor of the automated installation provided by `archinstall`. The installation instructions have been refined to include `nvidia-dkms`, which allows for automatic rebuilding of kernel modules with new kernel versions. An explanation of `dkms` and `lib32-nvidia-utils` has been added for clarity.

Fixes #121